### PR TITLE
Add support for setting the file mode

### DIFF
--- a/local/resource_local_file_test.go
+++ b/local/resource_local_file_test.go
@@ -14,15 +14,27 @@ import (
 func TestLocalFile_Basic(t *testing.T) {
 	var cases = []struct {
 		path    string
+		mode    os.FileMode
 		content string
 		config  string
 	}{
 		{
 			"local_file",
+			0777,
 			"This is some content",
 			`resource "local_file" "file" {
          content     = "This is some content"
          filename    = "local_file"
+      }`,
+		},
+		{
+			"other_local_file",
+			0644,
+			"some private content",
+			`resource "local_file" "file2" {
+         content  = "some private content"
+         filename = "other_local_file"
+         mode     = 0644
       }`,
 		},
 	}
@@ -41,6 +53,16 @@ func TestLocalFile_Basic(t *testing.T) {
 						if string(content) != tt.content {
 							return fmt.Errorf("config:\n%s\ngot:\n%s\nwant:\n%s\n", tt.config, content, tt.content)
 						}
+
+						fi, err := os.Stat(tt.path)
+						if err != nil {
+							return fmt.Errorf("config:\n%s\n,got: %s\n", tt.config, err)
+						}
+						mode := fi.Mode().Perm()
+						if mode != tt.mode {
+							return fmt.Errorf("config:\n%s\n, got: %s, want: %s\n", tt.config, mode, tt.mode)
+						}
+
 						return nil
 					},
 				},


### PR DESCRIPTION
We're using the `local_file` provider to manage files with sensitive content, so it's nice to be able to set the file permissions too.