### PR TITLE
[Feature] Implement convert of ~ to homedir. F.e.: ~ -> /home/user

### DIFF
--- a/local/data_source_local_file.go
+++ b/local/data_source_local_file.go
@@ -33,7 +33,7 @@ func dataSourceLocalFile() *schema.Resource {
 }
 
 func dataSourceLocalFileRead(d *schema.ResourceData, _ interface{}) error {
-	path := d.Get("filename").(string)
+	path := homeDirValidate(d.Get("filename").(string))
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err

--- a/local/resource_local_file.go
+++ b/local/resource_local_file.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -15,8 +16,8 @@ import (
 
 func homeDirValidate(s string) string {
 	if s[0] == '~' {
-		usersHomeDir, _ := os.UserHomeDir()
-		return filepath.Join(usersHomeDir, s[1:])
+		u, _ := user.Current()
+		return filepath.Join(u.HomeDir, s[1:])
 	}
 	return s
 }


### PR DESCRIPTION
Hi there.

I was working with local_file resource and found that when using the symbol "~" in filename the resource local_file create this file in folder where it was called. Steps to reproduce:

0. Prepare *.tf file with such content:
```bash
user@hostname:~/sandbox/local_file$ ls -la && pwd && cat main.tf 
total 12
drwxrwxr-x  2 user user 4096 Nov  8 11:24 .
drwxrwxr-x 30 user user 4096 Nov  8 11:22 ..
-rw-rw-r--  1 user user  104 Nov  8 11:17 main.tf
/home/user/sandbox/local_file
resource "local_file" "kubeconfig" {
  content    = "test-content"
  filename   = "~/.kube/kubeconfig"
}
```
1. run `terraform init` and `terraform apply` in this folder
```
user@hostname:~/sandbox/local_file$ terraform init && terraform apply

Initializing the backend...

Initializing provider plugins...
- Checking for available provider plugins...
- Downloading plugin for provider "local" (hashicorp/local) 1.4.0...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.local: version = "~> 1.4"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # local_file.kubeconfig will be created
  + resource "local_file" "kubeconfig" {
      + content              = "test-content"
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "~/.kube/kubeconfig"
      + id                   = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

local_file.kubeconfig: Creating...
local_file.kubeconfig: Creation complete after 0s [id=60b62e43b6a5e292b8fdbd41e57de248605d2c27]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
3. Check current folder where you've called `terraform`.
```bash
user@hostname:~/sandbox/local_file$ pwd && ls -alh
/home/user/sandbox/local_file
total 24K
drwxrwxr-x  3 user user 4,0K Nov  8 11:27 ~
drwxrwxr-x  4 user user 4,0K Nov  8 11:27 .
drwxrwxr-x 30 user user 4,0K Nov  8 11:22 ..
-rw-rw-r--  1 user user  104 Nov  8 11:17 main.tf
drwxr-xr-x  3 user user 4,0K Nov  8 11:27 .terraform
-rw-rw-r--  1 user user  743 Nov  8 11:27 terraform.tfstate
```
You can see `~` folder in the first line of the output, while file has not been create in /home/user/.kube/.
```bash
user@hostname:~/sandbox/local_file$ tree -a
/home/user/sandbox/local_file
.
├── ~
│   └── .kube
│       └── kubeconfig
├── main.tf
├── .terraform
│   └── plugins
│       └── linux_amd64
│           ├── lock.json
│           └── terraform-provider-local_v1.4.0_x4
└── terraform.tfstate
5 directories, 5 files
```

So, this pull request implement simple converting `~` to path `/home/user` of the user. Steps to check:
0. Replace binary in .terraform/plugins/linux_amd64
1. Remove current `terraform.state` file and run `terraform init && terraform apply`
2. File will be created in correct folder `/home/user/.kube/`
```bash
usero@hostname:~/.kube$ pwd && cat kubeconfig 
/home/user/.kube
test-content
```
