### PR TITLE
tree-wide: fix references to the terraform-providers organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,15 @@
 
 NOTES:
 
-* The provider has switched to the standalone TF SDK, there should be no noticeable impact on compatibility. ([#32](https://github.com/terraform-providers/terraform-provider-local/issues/32))
+* The provider has switched to the standalone TF SDK, there should be no noticeable impact on compatibility. ([#32](https://github.com/hashicorp/terraform-provider-local/issues/32))
 
 NEW FEATURES:
 
-* r/local_file: allow for configurable permissions ([#30](https://github.com/terraform-providers/terraform-provider-local/issues/30))
+* r/local_file: allow for configurable permissions ([#30](https://github.com/hashicorp/terraform-provider-local/issues/30))
 
 ## 1.3.0 (June 26, 2019)
 
-* Add support for base64 encoded content ([#29](https://github.com/terraform-providers/terraform-provider-local/issues/29))
+* Add support for base64 encoded content ([#29](https://github.com/hashicorp/terraform-provider-local/issues/29))
 
 ## 1.2.2 (May 01, 2019)
 
@@ -26,13 +26,13 @@ NEW FEATURES:
 NEW FEATURES:
 
 * The provider is now compatible with Terraform v0.12, while retaining compatibility with prior versions.
-* `local_file` resource has optional `sensitive_content` attribute, which can be used instead of `content` in situations where the content contains sensitive information that should not be displayed in a rendered diff. ([#9](https://github.com/terraform-providers/terraform-provider-local/issues/9))
+* `local_file` resource has optional `sensitive_content` attribute, which can be used instead of `content` in situations where the content contains sensitive information that should not be displayed in a rendered diff. ([#9](https://github.com/hashicorp/terraform-provider-local/issues/9))
 
 ## 1.1.0 (January 04, 2018)
 
 NEW FEATURES:
 
-* `local_file` data source, for reading files in a way that participates in Terraform's dependency graph, which allows reading of files that are created dynamically during `terraform apply`. ([#6](https://github.com/terraform-providers/terraform-provider-local/issues/6))
+* `local_file` data source, for reading files in a way that participates in Terraform's dependency graph, which allows reading of files that are created dynamically during `terraform apply`. ([#6](https://github.com/hashicorp/terraform-provider-local/issues/6))
 
 ## 1.0.0 (September 15, 2017)
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-local`
+Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-local`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-local
+$ mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp
+$ git clone git@github.com:hashicorp/terraform-provider-local
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-local
+$ cd $GOPATH/src/github.com/hashicorp/terraform-provider-local
 $ make build
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-local
+module github.com/hashicorp/terraform-provider-local
 
 require (
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-local/local"
+	"github.com/hashicorp/terraform-provider-local/local"
 )
 
 func main() {

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -24,7 +24,7 @@ else
   SED="sed -i.bak -r -e"
 fi
 
-PROVIDER_URL="https:\/\/github.com\/terraform-providers\/terraform-provider-local\/issues"
+PROVIDER_URL="https:\/\/github.com\/hashicorp\/terraform-provider-local\/issues"
 
 $SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 


### PR DESCRIPTION
`terraform-provider-local` has been moved to the `hashicorp`
organization.