### PR TITLE
Add sensitive option to local_file to suppress output in plan

### DIFF
--- a/internal/provider/data_source_local_file.go
+++ b/internal/provider/data_source_local_file.go
@@ -20,9 +20,19 @@ func dataSourceLocalFile() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
+			"sensitive": {
+				Type:        schema.TypeBool,
+				Description: "Treats content as sensitive and will not output it in plan",
+				Optional:    true,
+			},
 			"content": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"sensitive_content": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Computed:  true,
 			},
 			"content_base64": {
 				Type:     schema.TypeString,
@@ -38,8 +48,12 @@ func dataSourceLocalFileRead(d *schema.ResourceData, _ interface{}) error {
 	if err != nil {
 		return err
 	}
-
-	d.Set("content", string(content))
+	sensitive := d.Get("sensitive").(bool)
+	if sensitive {
+		d.Set("sensitive_content", string(content))
+	} else {
+		d.Set("content", string(content))
+	}
 	d.Set("content_base64", base64.StdEncoding.EncodeToString(content))
 
 	checksum := sha1.Sum([]byte(content))

--- a/internal/provider/data_source_local_file.go
+++ b/internal/provider/data_source_local_file.go
@@ -22,12 +22,13 @@ func dataSourceLocalFile() *schema.Resource {
 			},
 			"sensitive": {
 				Type:        schema.TypeBool,
-				Description: "Treats content as sensitive and will not output it in plan",
+				Description: "If set to true, the output content will be empty and the sensitive_content output will be populated instead.",
 				Optional:    true,
 			},
 			"content": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Description: "The raw content of the file that was read.",
+				Computed:    true,
 			},
 			"sensitive_content": {
 				Type:      schema.TypeString,
@@ -35,8 +36,9 @@ func dataSourceLocalFile() *schema.Resource {
 				Computed:  true,
 			},
 			"content_base64": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Description: "The base64 encoded version of the file content (use this when dealing with binary data).",
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_local_file.go
+++ b/internal/provider/data_source_local_file.go
@@ -27,17 +27,24 @@ func dataSourceLocalFile() *schema.Resource {
 			},
 			"content": {
 				Type:        schema.TypeString,
-				Description: "The raw content of the file that was read.",
+				Description: "The raw content of the file that was read, if sensitive is false. Otherwise an empty string.",
 				Computed:    true,
 			},
 			"sensitive_content": {
-				Type:      schema.TypeString,
-				Sensitive: true,
-				Computed:  true,
+				Type:        schema.TypeString,
+				Description: "The raw content of the file that was read, if sensitive is true. Otherwise an empty string.",
+				Sensitive:   true,
+				Computed:    true,
 			},
 			"content_base64": {
 				Type:        schema.TypeString,
-				Description: "The base64 encoded version of the file content (use this when dealing with binary data).",
+				Description: "The base64 encoded version of the file content (use this when dealing with binary data), if sensitive is false. Otherwise an empty string.",
+				Computed:    true,
+			},
+			"sensitive_content_base64": {
+				Type:        schema.TypeString,
+				Description: "The base64 encoded version of the file content, if sensitive is true. Otherwise an empty string.",
+				Sensitive:   true,
 				Computed:    true,
 			},
 		},
@@ -53,10 +60,11 @@ func dataSourceLocalFileRead(d *schema.ResourceData, _ interface{}) error {
 	sensitive := d.Get("sensitive").(bool)
 	if sensitive {
 		d.Set("sensitive_content", string(content))
+		d.Set("sensitive_content_base64", base64.StdEncoding.EncodeToString(content))
 	} else {
 		d.Set("content", string(content))
+		d.Set("content_base64", base64.StdEncoding.EncodeToString(content))
 	}
-	d.Set("content_base64", base64.StdEncoding.EncodeToString(content))
 
 	checksum := sha1.Sum([]byte(content))
 	d.SetId(hex.EncodeToString(checksum[:]))

--- a/internal/provider/data_source_local_file_test.go
+++ b/internal/provider/data_source_local_file_test.go
@@ -25,8 +25,46 @@ data "local_file" "file" {
 				Config: config,
 				Check: func(s *terraform.State) error {
 					m := s.RootModule()
+
 					i := m.Resources["data.local_file.file"].Primary
+
 					if got, want := i.Attributes["content"], content; got != want {
+						return fmt.Errorf("wrong content %q; want %q", got, want)
+					}
+					if got, want := i.Attributes["content_base64"], base64.StdEncoding.EncodeToString([]byte(content)); got != want {
+						return fmt.Errorf("wrong content_base64 %q; want %q", got, want)
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func TestLocalFileSensitiveDataSource(t *testing.T) {
+	content := "This is some content"
+
+	config := `
+	data "local_file" "file" {
+	  filename = "./testdata/local_file"
+	  sensitive = true
+	}
+	`
+
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: func(s *terraform.State) error {
+					m := s.RootModule()
+
+					i := m.Resources["data.local_file.file"].Primary
+
+					if got, want := i.Attributes["content"], ""; got != want {
+						return fmt.Errorf("Content was marked as sensitive and should not be returned in 'content' attribute")
+					}
+					if got, want := i.Attributes["sensitive_content"], content; got != want {
 						return fmt.Errorf("wrong content %q; want %q", got, want)
 					}
 					if got, want := i.Attributes["content_base64"], base64.StdEncoding.EncodeToString([]byte(content)); got != want {

--- a/internal/provider/data_source_local_file_test.go
+++ b/internal/provider/data_source_local_file_test.go
@@ -34,6 +34,12 @@ data "local_file" "file" {
 					if got, want := i.Attributes["content_base64"], base64.StdEncoding.EncodeToString([]byte(content)); got != want {
 						return fmt.Errorf("wrong content_base64 %q; want %q", got, want)
 					}
+					if got, want := i.Attributes["sensitive_content"], ""; got != want {
+						return fmt.Errorf("Content was not marked as sensitive and should be in 'content' attribute instead")
+					}
+					if got, want := i.Attributes["sensitive_content_base64"], ""; got != want {
+						return fmt.Errorf("Content was marked as sensitive and should be in 'content_base64' attribute instead")
+					}
 					return nil
 				},
 			},
@@ -64,10 +70,13 @@ func TestLocalFileSensitiveDataSource(t *testing.T) {
 					if got, want := i.Attributes["content"], ""; got != want {
 						return fmt.Errorf("Content was marked as sensitive and should not be returned in 'content' attribute")
 					}
+					if got, want := i.Attributes["content_base64"], ""; got != want {
+						return fmt.Errorf("Content was marked as sensitive and should not be returned in 'content_base64' attribute")
+					}
 					if got, want := i.Attributes["sensitive_content"], content; got != want {
 						return fmt.Errorf("wrong content %q; want %q", got, want)
 					}
-					if got, want := i.Attributes["content_base64"], base64.StdEncoding.EncodeToString([]byte(content)); got != want {
+					if got, want := i.Attributes["sensitive_content_base64"], base64.StdEncoding.EncodeToString([]byte(content)); got != want {
 						return fmt.Errorf("wrong content_base64 %q; want %q", got, want)
 					}
 					return nil

--- a/website/docs/d/file.html.md
+++ b/website/docs/d/file.html.md
@@ -10,27 +10,50 @@ description: |-
 
 `local_file` reads a file from the local filesystem.
 
-## Example Usage
+## Example usage (standard content)
 
 ```hcl
 data "local_file" "foo" {
     filename = "${path.module}/foo.bar"
 }
+
+resource "aws_s3_bucket_object" "shared_zip" {
+  bucket     = "my-bucket"
+  key        = "my-key"
+  content     = data.local_file.foo.content
+}
+```
+## Example Usage (with sensitive content)
+
+```hcl
+data "local_file" "foo" {
+    filename = "${path.module}/foo.bar"
+    sensitive = true
+}
+
+resource "aws_s3_bucket_object" "shared_zip" {
+  bucket     = "my-bucket"
+  key        = "my-key"
+  content     = data.local_file.foo.sensitive_content
+}
 ```
 
 ## Argument Reference
 
-The following argument is required:
+The following arguments are supported:
 
 * `filename` - (Required) The path to the file that will be read. The data
   source will return an error if the file does not exist.
+
+* `sensitive` - (Optional) Whether the output should be treated as sensitive. If set to true, the `content` output will be empty and the `sensitive_content` output will be populated instead.
 
 ## Attributes Exported
 
 The following attribute is exported:
 
-* `content` - The raw content of the file that was read.
+* `content` - The raw content of the file that was read. Returns empty if `sensitive` is true.
 * `content_base64` - The base64 encoded version of the file content (use this when dealing with binary data).
+* `sensitive_content` - If the `sensitive` argument is set to true, this will be populated with the raw content of the file.
 
 The content of the file must be valid UTF-8 due to Terraform's assumptions
 about string encoding. Files that do not contain UTF-8 text will have invalid

--- a/website/docs/d/file.html.md
+++ b/website/docs/d/file.html.md
@@ -10,7 +10,7 @@ description: |-
 
 `local_file` reads a file from the local filesystem.
 
-## Example usage (standard content)
+## Example Usage
 
 ```hcl
 data "local_file" "foo" {
@@ -23,10 +23,10 @@ resource "aws_s3_bucket_object" "shared_zip" {
   content     = data.local_file.foo.content
 }
 ```
-## Example Usage (with sensitive content)
+### Sensitive content
 
 ```hcl
-data "local_file" "foo" {
+data "local_file" "sensitive_foo" {
     filename = "${path.module}/foo.bar"
     sensitive = true
 }
@@ -34,7 +34,7 @@ data "local_file" "foo" {
 resource "aws_s3_bucket_object" "shared_zip" {
   bucket     = "my-bucket"
   key        = "my-key"
-  content     = data.local_file.foo.sensitive_content
+  content     = data.local_file.sensitive_foo.sensitive_content
 }
 ```
 
@@ -45,15 +45,15 @@ The following arguments are supported:
 * `filename` - (Required) The path to the file that will be read. The data
   source will return an error if the file does not exist.
 
-* `sensitive` - (Optional) Whether the output should be treated as sensitive. If set to true, the `content` output will be empty and the `sensitive_content` output will be populated instead.
+* `sensitive` - (Optional) Whether the output should be treated as sensitive. If set to true, the `content` attribute will be empty and the `sensitive_content` attribute will be populated instead.
 
 ## Attributes Exported
 
 The following attribute is exported:
 
-* `content` - The raw content of the file that was read. Returns empty if `sensitive` is true.
+* `content` - The raw content of the file that was read. It will be an empty string if `sensitive` is true.
 * `content_base64` - The base64 encoded version of the file content (use this when dealing with binary data).
-* `sensitive_content` - If the `sensitive` argument is set to true, this will be populated with the raw content of the file.
+* `sensitive_content` - This will be populated with the raw content of the file  only when the `sensitive` argument is set to `true`. Otherwise it will be an empty string.
 
 The content of the file must be valid UTF-8 due to Terraform's assumptions
 about string encoding. Files that do not contain UTF-8 text will have invalid

--- a/website/docs/d/file.html.md
+++ b/website/docs/d/file.html.md
@@ -52,8 +52,9 @@ The following arguments are supported:
 The following attribute is exported:
 
 * `content` - The raw content of the file that was read. It will be an empty string if `sensitive` is true.
-* `content_base64` - The base64 encoded version of the file content (use this when dealing with binary data).
+* `content_base64` - The base64 encoded version of the file content (use this when dealing with binary data). It will be an empty string if `sensitive` is true.
 * `sensitive_content` - This will be populated with the raw content of the file  only when the `sensitive` argument is set to `true`. Otherwise it will be an empty string.
+* `sensitive_content_base64` - This will be populated with the base64 encoded version of the file content only when the `sensitive` argument is set to `true`. Otherwise it will be an empty string.
 
 The content of the file must be valid UTF-8 due to Terraform's assumptions
 about string encoding. Files that do not contain UTF-8 text will have invalid


### PR DESCRIPTION
Add sensitive boolean attribute to data source local_file to output to sensitive_content field instead of content field.

Closes #36
Closes #64
