### PR TITLE
Temporarily disable publishing of `terraform-registry-manifest.json`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,9 +50,9 @@ publishers:
       - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
       - AWS_SESSION_TOKEN={{ .Env.AWS_SESSION_TOKEN }}
-    extra_files:
-      - glob: 'terraform-registry-manifest.json'
-        name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+#     extra_files:
+#       - glob: 'terraform-registry-manifest.json'
+#         name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
     name: hc-releases
     signature: true
 release:


### PR DESCRIPTION
This is necessary because of a recent change to `hc-releases` that before was silently skipping publishing the manifest. [Now it does instead fail and report the error](https://github.com/hashicorp/hc-releases/pull/150).

It turns out that GoReleaser was not actually passing in a file named `terraform-provider-local_VERSION_manifest.json`, as that is just a template: the file was provided as `terraform-registry-manifest.json`. And that is now picked up as invalid by `hc-releases`.

This is a temporary measure to allow for the release of `v2.2.0` of this provider.