### PR TITLE
docs: Fix YAML frontmatter in template

### DIFF
--- a/.changes/unreleased/NOTES-20240311-150450.yaml
+++ b/.changes/unreleased/NOTES-20240311-150450.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: No functional changes from v2.5.0. Fixed documentation YAML frontmatter.
+time: 2024-03-11T15:04:50.494913-04:00
+custom:
+  Issue: "303"

--- a/.changes/unreleased/NOTES-20240311-150450.yaml
+++ b/.changes/unreleased/NOTES-20240311-150450.yaml
@@ -1,5 +1,5 @@
 kind: NOTES
-body: No functional changes from v2.5.0. Fixed documentation YAML frontmatter.
+body: No functional changes from v2.5.0. Minor documentation fixes.
 time: 2024-03-11T15:04:50.494913-04:00
 custom:
   Issue: "303"

--- a/docs/functions/direxists.md
+++ b/docs/functions/direxists.md
@@ -1,3 +1,4 @@
+---
 page_title: "direxists function - terraform-provider-local"
 subcategory: ""
 description: |-

--- a/templates/functions/direxists.md.tmpl
+++ b/templates/functions/direxists.md.tmpl
@@ -1,3 +1,4 @@
+---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
 subcategory: ""
 description: |-


### PR DESCRIPTION
Follow up to #285 

I missed the beginning of the YAML frontmatter syntax 😞. Will be good to get the new docs `validate` command on this repository soon 🙂 