### PR TITLE
chore: Remove explicit RC release usage now that 1.14 is released

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,6 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
-          # TODO: Remove once Terraform 1.14 GA is released
-          terraform_version: 1.14.0-rc2
           terraform_wrapper: false
 
       - name: Generate


### PR DESCRIPTION
## Related Issue

N/A

## Description

Updates our CI to just use the latest version of Terraform (now 1.14, which supports actions) to generate documentation 👍🏻 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
