### PR TITLE
chore: prep for release v2.6.2

### DIFF
--- a/.changes/2.6.2.md
+++ b/.changes/2.6.2.md
@@ -1,0 +1,6 @@
+## 2.6.2 (January 28, 2026)
+
+NOTES:
+
+* all: This release introduces no functional changes. It was built using the latest 1.24 patch version of Go and re-released to address a certificate handshake issue. ([#461](https://github.com/hashicorp/terraform-provider-local/issues/461))
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.6.2 (January 28, 2026)
+
+NOTES:
+
+* all: This release introduces no functional changes. It was built using the latest 1.24 patch version of Go and re-released to address a certificate handshake issue. ([#461](https://github.com/hashicorp/terraform-provider-local/issues/461))
+
 ## 2.6.1 (November 17, 2025)
 
 BUG FIXES:
@@ -15,9 +21,7 @@ FEATURES:
 
 NOTES:
 
-* Update dependencies ([#404](https://github.com/hashicorp/terraform-provider-local/issues/404))
-
-## 2.5.3-alpha1 (April 24, 2025)
+* Update dependencies ([#404](https://github.com/hashicorp/terraform-provider-local/issues/404))## 2.5.3-alpha1 (April 24, 2025)
 
 NOTES:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-providers/terraform-provider-local
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/hashicorp/copywrite v0.22.0


### PR DESCRIPTION
## Description

Closes #461

Preparation for releasing v2.6.2

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
Nope