### PR TITLE
Fix incorrect reference to provider name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The remainder of this document will focus on the development aspects of the prov
 Compatibility table between this provider, the [Terraform Plugin Protocol](https://www.terraform.io/plugin/how-terraform-works#terraform-plugin-protocol)
 version it implements, and Terraform:
 
-| TLS Provider | Terraform Plugin Protocol | Terraform |
+| Local Provider | Terraform Plugin Protocol | Terraform |
 |:------------:|:-------------------------:|:---------:|
 |   `>= 2.x`   |            `5`            | `>= 0.12` |
 |  `>= 1.1.x`  |        `4` and `5`        | `<= 0.12` |


### PR DESCRIPTION
## Description

This fixes a reference in the readme file that calls this the "TLS Provider" rather than the "Local Provider". 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

No rollback needed, purely a documentation change. 

## Changes to Security Controls

No security related changes. 